### PR TITLE
Fixed NullReferenceException will occur when displaying the ToolTip I…

### DIFF
--- a/sources/Domain/DataModel/ValueContainers/Base/ValueContainer.cs
+++ b/sources/Domain/DataModel/ValueContainers/Base/ValueContainer.cs
@@ -59,7 +59,7 @@ namespace RevitDBExplorer.Domain.DataModel.ValueContainers.Base
         {
             get
             {
-                if (typeHandler is IHaveToolTip<T> typeHandlerWithToolTip)
+                if (value is not null && typeHandler is IHaveToolTip<T> typeHandlerWithToolTip)
                 {
                     return typeHandlerWithToolTip.GetToolTip(context, value);
                 }


### PR DESCRIPTION
Hi @NeVeSpl
I fixed NullReferenceException will occur when displaying the ToolTip If XYZ or UV is null.