### PR TITLE
Fixed cause NullReferenceException when selected Element.GetMaterialIds()

### DIFF
--- a/sources/RevitDBExplorer/Domain/DataModel/ValueContainers/Base/TypeHandler.cs
+++ b/sources/RevitDBExplorer/Domain/DataModel/ValueContainers/Base/TypeHandler.cs
@@ -14,8 +14,6 @@ namespace RevitDBExplorer.Domain.DataModel.ValueContainers.Base
 
         public Type Type => type;
 
-        Type ITypeHandler<T>.Type { get; }
-
         public string GetTypeHandlerName(T value)
         {
             var containerTypeName = Type.GetCSharpName();


### PR DESCRIPTION
Hi, @NeVeSpl .
I Fixed cause NullReferenceException when selected Element.GetMaterialIds().
