### PR TITLE
add split volumes

### DIFF
--- a/sources/RevitDBExplorer/Domain/DataModel/MemberTemplates/Solid_Templates.cs
+++ b/sources/RevitDBExplorer/Domain/DataModel/MemberTemplates/Solid_Templates.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using RevitDBExplorer.Domain.DataModel.MemberTemplates.Base;
+using RevitDBExplorer.Domain.DataModel.Streams;
+using RevitDBExplorer.Domain.DataModel.Streams.Base;
+
+// (c) Revit Database Explorer https://github.com/NeVeSpl/RevitDBExplorer/blob/main/license.md
+
+namespace RevitDBExplorer.Domain.DataModel.MemberTemplates
+{
+    internal class Solid_Templates : IHaveMemberTemplates
+    {
+        private static readonly IEnumerable<ISnoopableMemberTemplate> templates = Enumerable.Empty<ISnoopableMemberTemplate>();
+
+        static Solid_Templates()
+        {
+            templates = new ISnoopableMemberTemplate[]
+            {
+               SnoopableMemberTemplate<Solid>.Create((document, target) => SolidUtils.SplitVolumes(target), kind: MemberKind.StaticMethod),
+            };
+        }
+
+        public IEnumerable<ISnoopableMemberTemplate> GetTemplates()
+        {
+            return templates;
+        }
+    }
+}


### PR DESCRIPTION
Currently getting solid from any element will return a combined or merged solids, that actually doesn't reflect all the solids inside.
I have add Solid_Template class, which adds the actual solids inside.

see this example. a Model text contains multiple characters. snooping its geometry returns a single solid. splitting the solid, will break the merge to separate transformed solids
![image](https://github.com/NeVeSpl/RevitDBExplorer/assets/12208720/828e84d9-0cb1-45e3-9def-0d2bd0afa2a2)
