### PR TITLE
Added Adaptive component Instance Util

### DIFF
--- a/sources/RevitDBExplorer/Domain/DataModel/MemberTemplates/FamilyInstance_Templates.cs
+++ b/sources/RevitDBExplorer/Domain/DataModel/MemberTemplates/FamilyInstance_Templates.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using RevitDBExplorer.Domain.DataModel.MemberTemplates.Base;
+using RevitDBExplorer.Domain.DataModel.Streams;
+using RevitDBExplorer.Domain.DataModel.Streams.Base;
+
+// (c) Revit Database Explorer https://github.com/NeVeSpl/RevitDBExplorer/blob/main/license.md
+
+namespace RevitDBExplorer.Domain.DataModel.MemberTemplates
+{
+    internal class FamilyInstance_Templates : IHaveMemberTemplates
+    {
+        private static readonly IEnumerable<ISnoopableMemberTemplate> templates = Enumerable.Empty<ISnoopableMemberTemplate>();
+
+        static FamilyInstance_Templates()
+        {
+            templates = new ISnoopableMemberTemplate[]
+            {
+               SnoopableMemberTemplate<FamilyInstance>.Create((doc, target) => AdaptiveComponentInstanceUtils.GetInstancePlacementPointElementRefIds(target), kind: MemberKind.AsArgument),
+                
+            }; 
+        }
+
+        public IEnumerable<ISnoopableMemberTemplate> GetTemplates()
+        {
+            return templates;
+        }
+    }
+}

--- a/sources/RevitDBExplorer/Domain/DataModel/MemberTemplates/FamilyInstance_Templates.cs
+++ b/sources/RevitDBExplorer/Domain/DataModel/MemberTemplates/FamilyInstance_Templates.cs
@@ -17,8 +17,7 @@ namespace RevitDBExplorer.Domain.DataModel.MemberTemplates
         {
             templates = new ISnoopableMemberTemplate[]
             {
-               SnoopableMemberTemplate<FamilyInstance>.Create((doc, target) => AdaptiveComponentInstanceUtils.GetInstancePlacementPointElementRefIds(target), kind: MemberKind.AsArgument),
-                
+               SnoopableMemberTemplate<FamilyInstance>.Create((doc, target) => AdaptiveComponentInstanceUtils.GetInstancePlacementPointElementRefIds(target),canBeUsed: (x)=> AdaptiveComponentInstanceUtils.IsAdaptiveComponentInstance(x) , kind: MemberKind.AsArgument),
             }; 
         }
 


### PR DESCRIPTION
I think it will be helpful to  have Adaptive Component Instance Util. In short, it will allow snooping adaptive points within adaptive family instances

![image](https://github.com/NeVeSpl/RevitDBExplorer/assets/12208720/d11e8800-34ab-4e34-a370-112087a5da9b)

