### PR TITLE
NullReferenceException Fix for BoundingBox Selection of Linked Elements

### DIFF
--- a/sources/RevitDBExplorer/Domain/DataModel/MemberAccessors/Element/Element_BoundingBox.cs
+++ b/sources/RevitDBExplorer/Domain/DataModel/MemberAccessors/Element/Element_BoundingBox.cs
@@ -20,7 +20,10 @@ namespace RevitDBExplorer.Domain.DataModel.MemberAccessors
         private static IEnumerable<SnoopableObject> Snoop(Document document, Element element)
         {
             yield return new SnoopableObject(document, null, new[] { new SnoopableObject(document, element.get_BoundingBox(null)) }) { NamePrefix = "view:" };
-            yield return new SnoopableObject(document, null, new[] { new SnoopableObject(document, element.get_BoundingBox(document.ActiveView)) }) { NamePrefix = "view:", Name = "Active view: " + document.ActiveView.Name };
+            if (document.ActiveView != null)
+            {
+                yield return new SnoopableObject(document, null, new[] { new SnoopableObject(document, element.get_BoundingBox(document.ActiveView)) }) { NamePrefix = "view:", Name = "Active view: " + document.ActiveView.Name };
+            }
        
         }
     }


### PR DESCRIPTION
Fixed a NullReferenceException that occurs when selecting the BoundingBox item of a linked element.