### PR TITLE
Preserve document context in API snoop sources

### DIFF
--- a/sources/RevitDBExplorer/APIAdapter.cs
+++ b/sources/RevitDBExplorer/APIAdapter.cs
@@ -13,7 +13,7 @@ namespace RevitDBExplorer
         {
             var revitDocument = document as Document;
             var snoopableObjects = elements.Select(x => new SnoopableObject(revitDocument, x)).ToArray();
-            var sourceOfObjects = new SourceOfObjects(snoopableObjects) { Info = new InfoAboutSource("API.Snoop()") };            
+            var sourceOfObjects = new SourceOfObjects(snoopableObjects, revitDocument) { Info = new InfoAboutSource("API.Snoop()") };
 
             var window = new MainWindow(sourceOfObjects, Application.RevitWindowHandle);
             window.Show();

--- a/sources/RevitDBExplorer/Domain/SourceOfObjects.cs
+++ b/sources/RevitDBExplorer/Domain/SourceOfObjects.cs
@@ -40,6 +40,11 @@ namespace RevitDBExplorer.Domain
         {
             Objects = snoopableObjects ?? new SnoopableObject[0];
         }
+        public SourceOfObjects(IList<SnoopableObject> snoopableObjects, Document document)
+        {
+            Objects = snoopableObjects ?? new SnoopableObject[0];
+            RevitDocument = document;
+        }
 
 
         public void ReadFromTheSource(UIApplication uiApplication)


### PR DESCRIPTION
APIAdapter.Snoop() receives a Revit Document, but dropped it when constructing SourceOfObjects, leaving it unset which then breaks downstream UI code.

This change adds a SourceOfObjects overload that accepts a Document (and sets it to SourceOfObjects.RevitDocument) and uses the new overload in APIAdapter.

When entering from the api, this also avoids the selection-sync crash path fixed separately in 6bb4ed5 because API source now carries the document context the UI expects.